### PR TITLE
chore: NICE 신모듈 cutover 전 호출자 origin 임시 로깅

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,16 @@ const requestHandler: http.RequestListener = async (
   res: http.ServerResponse
 ) => {
   const { method, url } = req;
+  // [임시] 신모듈 cutover 전 호출자 origin 인벤토리 — 검증 끝나면 제거
+  console.log(JSON.stringify({
+    t: new Date().toISOString(),
+    m: method,
+    u: url,
+    ua: req.headers["user-agent"],
+    ref: req.headers["referer"],
+    orig: req.headers["origin"],
+    xff: req.headers["x-forwarded-for"],
+  }));
   const _url = new URL(<string>url, process.env.NICE_SERVER_HOSTNAME);
 
   const CORSHeader = {


### PR DESCRIPTION
## Summary
- NICE 신모듈(`chabot-neoauth-server`) cutover 전, 현 서버 호출자 인벤토리 확보를 위한 단발성 request meta 로깅 추가
- 로깅 항목: timestamp, method, url, user-agent, referer, origin, x-forwarded-for
- 1~2일 운영 후 pm2 로그의 referer/origin 분포 분석 → 알려진 web/app/webview 외 잔존 호출자 색출 목적
- 검증 끝나면 본 PR revert 또는 옛 서버 폐기와 함께 정리 예정

## Test plan
- [ ] 배포 후 pm2 로그에 JSON 한 줄이 요청마다 찍히는지 확인
- [ ] 로깅으로 인한 응답 지연/에러 없는지 확인
- [ ] 1~2일 후 로그 수집해 호출자 분포 정리
- [ ] 분석 완료 후 revert PR 또는 옛 서버 폐기 작업과 함께 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)