### PR TITLE
chore: sync CORSHeader Allow-Origin with prod (*)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -28,7 +28,7 @@ const requestHandler: http.RequestListener = async (
   const _url = new URL(<string>url, process.env.NICE_SERVER_HOSTNAME);
 
   const CORSHeader = {
-  'Access-Control-Allow-Origin': 'https://buy-car.chabot.co.kr',
+  'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Accept',
   'Access-Control-Max-Age': 0,


### PR DESCRIPTION
## Summary
- prod(EC2)에서 미커밋 상태로 운영되고 있던 `CORSHeader['Access-Control-Allow-Origin']` 값을 소스에 반영
- 변경: `'https://buy-car.chabot.co.kr'` → `'*'`
- 동작 변경 없음 — 실서버는 이미 `*`로 동작 중이었고, 본 PR은 **소스 ↔ 실서버 상태 동기화** 목적

## Context
- 본 서버는 `chabot-neoauth-server` cutover 예정 (#2 의 request-meta 로깅도 그 사전 작업)
- 그 전까지의 prod 상태가 git에 남아있지 않으면 다음 작업자가 `git checkout` 한 방에 의도치 않게 되돌릴 위험이 있어 정식 커밋으로 박아둠

## ⚠️ Security note
- `Access-Control-Allow-Origin: *`는 모든 origin 허용 → 일반적으로 권장되지 않음
- 현 서버는 곧 폐기되므로 이 PR에선 그대로 두지만, **신모듈(`chabot-neoauth-server`)에서는 동일 설정 사용 여부 재검토 필요**

## Test plan
- [ ] PR 머지 후 EC2에서 `git checkout -- src/app.ts && git pull --ff-only` 로 동기화
- [ ] `git diff origin/main -- src/app.ts` 가 비어 있는지 확인
- [ ] `npm run build && pm2 restart NiceAuthorizationService` 후 정상 응답 확인
- [ ] 기존 `buy-car.chabot.co.kr` 호출 정상 동작 확인 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)